### PR TITLE
WK Item Info Injector

### DIFF
--- a/user_scripts/rendaku_information.user.js
+++ b/user_scripts/rendaku_information.user.js
@@ -13,7 +13,7 @@
 // @updateURL   https://raw.githubusercontent.com/jameshippisley/wanikani/master/user_scripts/rendaku_information.user.js
 // @downloadURL https://raw.githubusercontent.com/jameshippisley/wanikani/master/user_scripts/rendaku_information.user.js
 //
-// @require     https://greasyfork.org/scripts/430565-wanikani-item-info-injector/code/WaniKani%20Item%20Info%20Injector.user.js?version=958983
+// @require     https://greasyfork.org/scripts/430565-wanikani-item-info-injector/code/WaniKani%20Item%20Info%20Injector.user.js?version=961902
 // @require     https://raw.githubusercontent.com/jameshippisley/wanikani/51ec0bb201f179ac632dc9c0f4aa64b778428f39/user_scripts/rendaku_information_data.json
 //
 // @run-at      document-end


### PR DESCRIPTION
WaniKani is currently changing their website to use React. [The newest change of the lesson screen](https://community.wanikani.com/t/52617) breaks the Rendaku Information script (or more specifically, the `wk_interaction.js` that this script uses). As a replacement of `wk_interaction.js`, I have created [a new library script called WK Item Info Injector](https://community.wanikani.com/t/52617/38) that other scripts can use to insert additional item information into WK. This pull request modifies the Rendaku Information script to use WK Item Info Injector instead of `wk_interaction.js` so that it works on the new lesson screen.